### PR TITLE
add mobileview option (replaces count and enableNavigator).

### DIFF
--- a/src/chartWindow.js
+++ b/src/chartWindow.js
@@ -32,6 +32,9 @@ let idCounter = 0;
 export const addNewChart = function($parent, options) {
     const dialog = $(html);
     $parent.addClass('chart-dialog');
+    if (options.enableMobileView) {
+        $parent.addClass('mobile-chart');
+    }
     dialog.appendTo($parent);
     var id = `webtrader-charts-dialog-${++idCounter}`;
     dialog.attr('id', id);

--- a/src/charts.js
+++ b/src/charts.js
@@ -243,8 +243,11 @@ export const drawChart = (containerIDWithHash, options, onload) => {
         overlays = [];
     }
 
+    const isMobile = $(containerIDWithHash).parents().eq(2).hasClass('mobile-chart');
+    
     //Save some data in DOM
     $(containerIDWithHash).data({
+        enableMobileView: isMobile,
         instrumentCode: options.instrumentCode,
         instrumentName: options.instrumentName,
         timePeriod: options.timePeriod,
@@ -514,7 +517,6 @@ export const triggerReflow = (containerIDWithHash) => {
 export const refresh = function(containerIDWithHash, newTimePeriod, newChartType, indicators, overlays) {
     const dialog = $(containerIDWithHash);
     const options = $(containerIDWithHash).data();
-    const isMobile = $(containerIDWithHash).parents().eq(2).hasClass('mobile-chart');
     if (newTimePeriod) {
         //Unsubscribe from tickstream.
         chartingRequestMap.unregister_all(containerIDWithHash);
@@ -564,7 +566,7 @@ export const refresh = function(containerIDWithHash, newTimePeriod, newChartType
          timePeriod: options.timePeriod,
          timezoneOffset: options.timezoneOffset || 0,
          type: options.type,
-         enableMobileView: isMobile,
+         enableMobileView: options.enableMobileView,
          series_compare: series_compare,
          delayAmount: options.delayAmount,
          overlays: overlays,

--- a/src/charts.js
+++ b/src/charts.js
@@ -19,6 +19,7 @@ import { toggleCrossHair } from './crosshair.js';
 import chartDraw from './chartDraw.js';
 
 import './charts.scss';
+import './mobileview.scss';
 
 // TODO: moemnt locale
 // const lang = local_storage.get("i18n") ? local_storage.get("i18n").value.replace("_","-") : 'en';
@@ -255,6 +256,7 @@ export const drawChart = (containerIDWithHash, options, onload) => {
 
     var initialized = false;
     const container = $(containerIDWithHash);
+    const enableMobileView = options.enableMobileView === undefined ? false : options.enableMobileView;
     // Create the chart
     $(containerIDWithHash).highcharts('StockChart', {
         chart: {
@@ -318,7 +320,7 @@ export const drawChart = (containerIDWithHash, options, onload) => {
         },
 
         navigator: {
-            enabled: options.enableNavigator === undefined ? true : options.enableNavigator,
+            enabled: !enableMobileView,
             series: {
                 id: 'navigator'
             }
@@ -512,6 +514,7 @@ export const triggerReflow = (containerIDWithHash) => {
 export const refresh = function(containerIDWithHash, newTimePeriod, newChartType, indicators, overlays) {
     const dialog = $(containerIDWithHash);
     const options = $(containerIDWithHash).data();
+    const isMobile = $(containerIDWithHash).parents().eq(2).hasClass('mobile-chart');
     if (newTimePeriod) {
         //Unsubscribe from tickstream.
         chartingRequestMap.unregister_all(containerIDWithHash);
@@ -561,6 +564,7 @@ export const refresh = function(containerIDWithHash, newTimePeriod, newChartType
          timePeriod: options.timePeriod,
          timezoneOffset: options.timezoneOffset || 0,
          type: options.type,
+         enableMobileView: isMobile,
          series_compare: series_compare,
          delayAmount: options.delayAmount,
          overlays: overlays,

--- a/src/common/ohlc_handler.js
+++ b/src/common/ohlc_handler.js
@@ -91,7 +91,7 @@ export const retrieveChartDataAndRender = (options) => {
       granularity: timePeriod,
       style: !is_tick ? 'candles' : 'ticks',
       delayAmount: options.delayAmount,
-      count: options.count || 1000, //We are only going to request 1000 bars if possible
+      count: options.enableMobileView ? 100 : 1000, //We are only going to request 1000 bars if possible
       adjust_start_time: 1,
       start: options.start,
       end: options.end,

--- a/src/mobileview.scss
+++ b/src/mobileview.scss
@@ -1,0 +1,29 @@
+.mobile-chart {
+    $scroll-bar-height: 7px;
+
+    .highcharts-scrollbar-button {
+        fill: transparent;
+        stroke: transparent;
+        height: $scroll-bar-height;
+    }
+
+    .highcharts-scrollbar-arrow {
+        fill: transparent;
+    }
+
+    .highcharts-scrollbar-thumb {
+        height: $scroll-bar-height;
+        rx: $scroll-bar-height;
+        ry: $scroll-bar-height;
+    }
+
+    .highcharts-scrollbar-track {
+        height: $scroll-bar-height;
+        rx: $scroll-bar-height;
+        ry: $scroll-bar-height;
+    }
+
+    .highcharts-scrollbar-rifles {
+        stroke: transparent;
+    }
+}


### PR DESCRIPTION
Understandably, the code I added to detect mobile is pretty damn ugly in `charts.js`, but the options passed to `addNewCharts` method is not made available to the `charts` object. Making the code intuitive is tricky due to the design of the `charts` abstraction: each chart is not seen as an individual object, but a single `charts` controls all charts. This is why the element id needs to passed for every single function call in `charts`. Attributes of each chart is then attached to DOM elements via jQuery's `data()` method, which currently only assumes a single attribute `options`.

Yes, this is not good OOP design, but god knows how long refactoring will take... so this will do (: